### PR TITLE
HT-6266: Move to new environment-based hosted-zones

### DIFF
--- a/elb.tf
+++ b/elb.tf
@@ -83,7 +83,7 @@ resource "aws_lb" "default" {
 
 resource "aws_route53_record" "default" {
   zone_id = var.zone_id
-  name    = "${var.environment}-${var.record_name}"
+  name    = "${var.record_name}"
   type    = var.type
 
   alias {

--- a/main.tf
+++ b/main.tf
@@ -461,7 +461,7 @@ resource "aws_emr_instance_group" "task" {
 module "dns_master" {
   source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
   enabled = var.enabled && var.zone_id != null && var.zone_id != "" ? true : false
-  name    = var.master_dns_name != null && var.master_dns_name != "" ? var.master_dns_name : "emr-master-${var.environment}-${var.name}"
+  name    = var.master_dns_name != null && var.master_dns_name != "" ? var.master_dns_name : "emr-master-${var.name}"
   zone_id = var.zone_id
   records = coalescelist(aws_emr_cluster.default.*.master_public_dns, [""])
 }


### PR DESCRIPTION
## Ticket
[Ticket.](https://humnai.atlassian.net/browse/HT-6266)
## Changes
* Change the hard coded Route53 record names so that the environment is not in the bottom-level name.
  * `dev-kylin.rideshur.com` would become `kylin.rideshur.com`
  * `emr-master-dev-kylin.rideshur.com` would become `emr-master-kylin.rideshur.com`
## Notes
The zone ID variable must be updated next time the clusters are redeployed, so that they are deployed into their environment-based hosted zones.